### PR TITLE
fix: replace blob.bytes() function with blob.arrayBuffer()

### DIFF
--- a/ui/src/pages/CreateFileBackupPage.svelte
+++ b/ui/src/pages/CreateFileBackupPage.svelte
@@ -17,7 +17,7 @@
 
     const file = files[0];
     const resultGo = window.paperBackup(
-      await file.bytes(),
+      new Uint8Array(await file.arrayBuffer()),
       file.name ? file.name : "unknown.data",
       passphrase,
     );


### PR DESCRIPTION
The bytes() function is too new to use.

Fixes #7.